### PR TITLE
INTLY-1540: Remove MAVEN_MIRROR_URL value (nexus)

### DIFF
--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -34,7 +34,7 @@ parameters:
 - name: MAVEN_MIRROR_URL
   description: Maven Nexus Repository to be used during build phase
   displayName:
-  value: 'http://nexus.nexus.svc:8081/nexus/content/groups/public'
+  value: ''
   required: false
 - name: BUILDER_IMAGE_NAME
   description: Name of the image to use as a builder image


### PR DESCRIPTION
## Motivation
JIRA: https://issues.jboss.org/browse/INTLY-1540

## What
Remove value for MAVEN_MIRROR_URL (nexus.nexus.svc)

## Why
Current value doesn't take into account ns_prefix ("openshift-") for the nexus namespace.

## Verification Steps
Create a branch of https://github.com/integr8ly/launcher-booster-catalog that will reference `INTLY-1540` ([in here](https://github.com/integr8ly/launcher-booster-catalog/blob/master/fuse/redhat/aggregation/booster.yaml#L6-L15))
Choose a cluster with nexus installed in a namespace with prefix (e.g. openshift-nexus).
Edit launcher config map to use your branch and create and launch this booster from your launcher.
The app should build successfully. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

## Progress

- [x] Finished code change
- [x] Update catalog and test
