### PR TITLE
INTLY-2934 - Remove  resource  requests and limits

### DIFF
--- a/.openshiftio/application.yaml
+++ b/.openshiftio/application.yaml
@@ -282,13 +282,7 @@ objects:
           - containerPort: 8080
             name: http
             protocol: TCP
-          resources:
-            limits:
-              cpu: 100m
-              memory: 30Mi
-            requests:
-              cpu: 100m
-              memory: 15Mi
+          resources: {}
           securityContext:
             privileged: false
           volumeMounts:
@@ -335,13 +329,7 @@ objects:
           - containerPort: 8080
             name: http
             protocol: TCP
-          resources:
-            limits:
-              cpu: 100m
-              memory: 30Mi
-            requests:
-              cpu: 100m
-              memory: 15Mi
+          resources: {}
           securityContext:
             privileged: false
           volumeMounts:


### PR DESCRIPTION
See https://issues.jboss.org/browse/INTLY-2934.

This avoids potentially a higher project limitrange preventing this from being deployed (e.g. in OSD)

These are only training/tutorial/demo apps, so it's not important for limits to be set.

